### PR TITLE
Print dist update usage during ballerina update

### DIFF
--- a/resources/bin/ballerina
+++ b/resources/bin/ballerina
@@ -61,6 +61,8 @@ then
         fi
         rm -rf $CURRENT_PATH/../ballerina-command-tmp
         echo "Update successfully completed"
+        echo
+        echo "If you want to update the Ballerina distribution, use 'ballerina dist update'"
         exit 0
     fi
 fi

--- a/resources/bin/ballerina.bat
+++ b/resources/bin/ballerina.bat
@@ -68,6 +68,8 @@ if "%dist%" == "true" (
         )
         rd /s /q %CURRENT_PATH%\..\ballerina-command-tmp
         echo Update successfully completed
+        echo.
+        echo "If you want to update the Ballerina distribution, use 'ballerina dist update'"
         exit /b
    )
 )

--- a/src/main/java/org/ballerinalang/command/cmd/UpdateToolCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/UpdateToolCommand.java
@@ -83,7 +83,7 @@ public class UpdateToolCommand extends Command implements BCommand {
 
     private static void updateCommands(PrintStream printStream) {
         String version = ToolUtil.getCurrentToolsVersion();
-        printStream.println("Fetching the latest version from the remote server...");
+        printStream.println("Fetching the latest tool version from the remote server...");
         String latestVersion = ToolUtil.getLatestToolVersion();
         if (latestVersion == null) {
             printStream.println("Failed to find the latest tool version");
@@ -91,6 +91,7 @@ public class UpdateToolCommand extends Command implements BCommand {
         }
         if (latestVersion.equals(version)) {
             printStream.println("The latest tool version '" + latestVersion + "' is already in use");
+            printStream.println("\nIf you want to update the Ballerina distribution, use `ballerina dist update`");
             return;
         }
         ToolUtil.downloadTool(printStream, latestVersion);

--- a/src/main/resources/cli-help/ballerina-update.help
+++ b/src/main/resources/cli-help/ballerina-update.help
@@ -7,3 +7,4 @@ SYNOPSIS
 
 DESCRIPTION
        Update updates the Ballerina tool to the latest version.
+       If you want to update the Ballerina distribution use `ballerina dist update`.


### PR DESCRIPTION
## Purpose
> To print the dist update during dist update. If the user mistakenly uses ballerina update to update the distribution it would be better to print how to update the distribution. 
> Fixes https://github.com/ballerina-platform/ballerina-lang/issues/21416
