### PR TITLE
Disable auto-activation of pulled distrubition

### DIFF
--- a/src/main/java/org/ballerinalang/command/cmd/PullCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/PullCommand.java
@@ -70,7 +70,8 @@ public class PullCommand extends Command implements BCommand {
         }
         ToolUtil.downloadDistribution(printStream, distribution, distributionType, distributionVersion);
         ToolUtil.useBallerinaVersion(printStream, distribution);
-        printStream.println("'" + distribution + "' successfully set as the active distribution");
+        printStream.println("'" + distribution + "' successfully downloaded");
+        printStream.println("You can use " + "'" + "ballerina dist use " + distribution + "' to activate " + distribution);
     }
 
     @Override

--- a/src/main/java/org/ballerinalang/command/cmd/PullCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/PullCommand.java
@@ -69,7 +69,6 @@ public class PullCommand extends Command implements BCommand {
             return;
         }
         ToolUtil.downloadDistribution(printStream, distribution, distributionType, distributionVersion);
-        ToolUtil.useBallerinaVersion(printStream, distribution);
         printStream.println("'" + distribution + "' successfully downloaded");
         printStream.println("You can use " + "'" + "ballerina dist use " + distribution + "' to activate " + distribution);
     }

--- a/src/main/resources/cli-help/ballerina-dist-pull.help
+++ b/src/main/resources/cli-help/ballerina-dist-pull.help
@@ -1,13 +1,12 @@
 NAME
-       ballerina-dist-pull - Fetch a given distribution and set it as the active version
+       ballerina-dist-pull - Fetch a given distribution
 
 SYNOPSIS
        ballerina dist pull <distribution>
 
 
 DESCRIPTION
-       Pull fetches the specified distribution with its dependencies to your local environment and
-       marks it as the active version.
+       Pull fetches the specified distribution with its dependencies to your local environment
 
        The update command always fetches the latest patch version whereas the pull command gives
        you the flexibility to fetch and use any distribution.
@@ -17,5 +16,5 @@ DESCRIPTION
 
 
 EXAMPLES
-       This command fetches "jballerina-1.0.5" and marks it as the active distribution.
+       This command fetches "jballerina-1.0.5" distribution.
           $ ballerina dist pull jballerina-1.0.5

--- a/src/main/resources/cli-help/ballerina-dist.help
+++ b/src/main/resources/cli-help/ballerina-dist.help
@@ -20,7 +20,7 @@ BALLERINA COMMANDS
        Here is a list of available subcommands:
 
        update     Update to the latest patch version of the active distribution
-       pull       Fetch a distribution and set it as the active version
+       pull       Fetch a distribution
        use        Set a distribution as the active distribution
        list       List locally and remotely available distributions
        remove     Remove distributions in your local environment


### PR DESCRIPTION
## Purpose
Currently pull command activates pulled distribution and with the increased amount of versions activation of a pulled version breaks work flow. 

## Goals
Activation of pulled version is removed and a help message is added how to activate pulled distribution

## Release note
`ballerina dist pull` commands does not activate pulled distribution

## Documentation
If PR is accepted I'll update https://ballerina.io/v1-2/learn/how-to-keep-ballerina-up-to-date/

## Test environment
jdk8u202-b08-jre
Windows 10 Education 19041.153 
 