### PR TITLE
Improve  bal dist list command

### DIFF
--- a/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
@@ -51,6 +51,12 @@ public class ListCommand extends Command implements BCommand {
     @CommandLine.Option(names = {"--help", "-h", "?"}, hidden = true)
     private boolean helpFlag;
 
+    @CommandLine.Option(names = {"--all", "-a"}, hidden = true)
+    private boolean allFlag;
+
+    @CommandLine.Option(names = {"--pre-releases", "-pr"}, hidden = true)
+    private boolean prFlag;
+
     private CommandLine parentCmdParser;
 
     public ListCommand(PrintStream printStream) {
@@ -64,7 +70,7 @@ public class ListCommand extends Command implements BCommand {
         }
 
         if (listCommands == null) {
-            listDistributions(getPrintStream());
+            listDistributions(getPrintStream(), allFlag );
             return;
         }
 
@@ -98,7 +104,7 @@ public class ListCommand extends Command implements BCommand {
      *
      * @param outStream stream outputs need to be printed
      */
-    private static void listDistributions(PrintStream outStream) {
+    private static void listDistributions(PrintStream outStream, boolean allFlag) {
         String currentBallerinaVersion = ToolUtil.getCurrentBallerinaVersion();
         File folder = new File(ToolUtil.getDistributionsPath());
         File[] listOfFiles = folder.listFiles();
@@ -130,8 +136,7 @@ public class ListCommand extends Command implements BCommand {
                                         JSONObject versionInfo = new JSONObject();
                                         versionInfo.put("name", versionName);
                                         versionInfo.put("version", versionId);
-                                        outStream.println(markVersion(currentBallerinaVersion, versionId)
-                                                + " " + versionName);
+                                        outStream.println(markVersion(currentBallerinaVersion, versionId));
                                         releases.add(versionInfo);
                                     }
                                 }
@@ -145,10 +150,35 @@ public class ListCommand extends Command implements BCommand {
             writeLocalDistsIntoJson(distList);
             outStream.println("\nDistributions available remotely:");
             for (Channel channel : channels) {
-                outStream.println("\n" + channel.getName() + "\n");
-                for (Distribution distribution : channel.getDistributions()) {
-                    outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion())
-                            + " " + distribution.getName());
+                if (channel.getName().contains("pre-release") && !prFlag) {
+                    continue;
+                }
+                else {
+                    outStream.println("\n" + channel.getName() + "\n");
+                    if (!allFlag){
+                        if (channel.getDistributions().size() > 10) {
+                            outStream.println("... To list all the previous distributions execute `bal dist list -a`");
+                            int numDistributions = channel.getDistributions().size();
+                            List<Distribution> recentDistributions = channel.getDistributions().subList(numDistributions-10,
+                                    numDistributions);
+                            for (Distribution distribution : recentDistributions) {
+                                outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion(),
+                                        channel.getDistributions().get(numDistributions-1).getVersion()));
+                            }
+                        }
+                        else{
+                            for (Distribution distribution : channel.getDistributions()) {
+                                outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion(),
+                                        channel.getDistributions().get(channel.getDistributions().size()-1).getVersion()));
+                            }
+                        }
+                    }
+                    else{
+                        for (Distribution distribution : channel.getDistributions()) {
+                            outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion(),
+                                    channel.getDistributions().get(channel.getDistributions().size()-1).getVersion()));
+                        }
+                    }
                 }
             }
         } catch (CommandException e) {
@@ -173,11 +203,31 @@ public class ListCommand extends Command implements BCommand {
      * @param current Version needs to be checked
      * @return Marked output
      */
-    private static String markVersion(String used, String current) {
-        if (used.equals(current)) {
-            return "* [" + current + "]";
-        } else {
-            return "  [" + current + "]";
+    private static String markVersion(String used, String current, String ... latest) {
+        if (latest.length==1) {
+            if (used.equals(current)) {
+                if (current.equals(latest[0])){
+                    return "* " + current + " - latest" ;
+                }
+                else{
+                    return "* " + current ;
+                }
+            } else {
+                if (current.equals(latest[0])){
+                    return "  " + current + " - latest" ;
+                }
+                else{
+                    return "  " + current ;
+                }
+
+            }
+        }
+        else{
+            if (used.equals(current)) {
+                return "* " + current ;
+            } else {
+                return "  " + current ;
+            }
         }
     }
 
@@ -225,8 +275,7 @@ public class ListCommand extends Command implements BCommand {
                 JSONArray releases = (JSONArray) channelObj.get("releases");
                 for (Object release : releases) {
                     JSONObject versionInfo = (JSONObject) release;
-                    outStream.println(markVersion(currentBallerinaVersion, versionInfo.get("version").toString()) +
-                            " " + versionInfo.get("name").toString());
+                    outStream.println(markVersion(currentBallerinaVersion, versionInfo.get("version").toString()));
                 }
             }
         } catch (IOException | ParseException e) {
@@ -249,7 +298,7 @@ public class ListCommand extends Command implements BCommand {
                 if (parts.length == 2) {
                     version = parts[1];
                 }
-                outStream.println(markVersion(currentBallerinaVersion, version) + " " + ToolUtil.getTypeName(version));
+                outStream.println(markVersion(currentBallerinaVersion, version));
             }
         }
     }

--- a/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
@@ -70,7 +70,7 @@ public class ListCommand extends Command implements BCommand {
         }
 
         if (listCommands == null) {
-            listDistributions(getPrintStream(), allFlag );
+            listDistributions(getPrintStream(), allFlag, prFlag);
             return;
         }
 
@@ -104,7 +104,7 @@ public class ListCommand extends Command implements BCommand {
      *
      * @param outStream stream outputs need to be printed
      */
-    private static void listDistributions(PrintStream outStream, boolean allFlag) {
+    private static void listDistributions(PrintStream outStream, boolean allFlag, boolean prFlag) {
         String currentBallerinaVersion = ToolUtil.getCurrentBallerinaVersion();
         File folder = new File(ToolUtil.getDistributionsPath());
         File[] listOfFiles = folder.listFiles();

--- a/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
@@ -204,23 +204,16 @@ public class ListCommand extends Command implements BCommand {
      * @return Marked output
      */
     private static String markVersion(String used, String current, String ... latest) {
-        if (latest.length==1) {
+        if (latest.length == 1) {
+            String usedMarker = "  ";
+            String latestMarker = "";
             if (used.equals(current)) {
-                if (current.equals(latest[0])){
-                    return "* " + current + " - latest" ;
-                }
-                else{
-                    return "* " + current ;
-                }
-            } else {
-                if (current.equals(latest[0])){
-                    return "  " + current + " - latest" ;
-                }
-                else{
-                    return "  " + current ;
-                }
-
+                usedMarker = "* ";
             }
+            if (current.equals(latest[0])) {
+                latestMarker = " - latest" ;
+            }
+            return usedMarker + current + latestMarker;
         }
         else{
             if (used.equals(current)) {

--- a/src/main/resources/cli-help/ballerina-dist-list.help
+++ b/src/main/resources/cli-help/ballerina-dist-list.help
@@ -6,20 +6,20 @@ SYNOPSIS
 
 OPTIONS
        -pr, --pre-releases
-          List the distributions available for you to download under pre-releases channel.
+          List the distributions that are available for you to download under the pre-releases channel.
 
        -a, --all
-          List all the distributions available for you to download under each channel.
+          List all the distributions that are available for you to download under each channel.
 
 DESCRIPTION
        List all the distributions installed in your local environment
        as well as the distributions that are available for you to download.
 
 EXAMPLES
-       List latest distributions under major channels.
+       List the latest distributions under the major channels.
          $ bal dist list
 
-       List all the distributions under major channels.
+       List all the distributions under the major channels.
          $ bal dist list -a
 
        List all the distributions under all the channels (including pre-releases).

--- a/src/main/resources/cli-help/ballerina-dist-list.help
+++ b/src/main/resources/cli-help/ballerina-dist-list.help
@@ -4,6 +4,23 @@ NAME
 SYNOPSIS
        bal dist list
 
+OPTIONS
+       -pr, --pre-releases
+          List the distributions available for you to download under pre-releases channel.
+
+       -a, --all
+          List all the distributions available for you to download under each channel.
+
 DESCRIPTION
        List all the distributions installed in your local environment
        as well as the distributions that are available for you to download.
+
+EXAMPLES
+       List latest distributions under major channels.
+         $ bal dist list
+
+       List all the distributions under major channels.
+         $ bal dist list -a
+
+       List all the distributions under all the channels (including pre-releases).
+         $ bal dist list -a -pr

--- a/src/test/java/org/ballerinalang/command/ListCommandTest.java
+++ b/src/test/java/org/ballerinalang/command/ListCommandTest.java
@@ -40,7 +40,7 @@ public class ListCommandTest extends CommandTest {
         Assert.assertTrue(outContent.toString().contains("1.* channel"));
         Assert.assertTrue(outContent.toString().contains("1.2.20"));
         Assert.assertTrue(outContent.toString().contains("Swan Lake channel"));
-        Assert.assertTrue(outContent.toString().contains("slbeta3"));
+        Assert.assertTrue(outContent.toString().contains("2201"));
     }
 
     @Test

--- a/src/test/java/org/ballerinalang/command/ListCommandTest.java
+++ b/src/test/java/org/ballerinalang/command/ListCommandTest.java
@@ -38,9 +38,9 @@ public class ListCommandTest extends CommandTest {
         Assert.assertTrue(outContent.toString().contains("Distributions available locally"));
         Assert.assertTrue(outContent.toString().contains("Distributions available remotely"));
         Assert.assertTrue(outContent.toString().contains("1.* channel"));
-        Assert.assertTrue(outContent.toString().contains("[1.0.1] jballerina version 1.0.1"));
+        Assert.assertTrue(outContent.toString().contains("1.2.20"));
         Assert.assertTrue(outContent.toString().contains("Swan Lake channel"));
-        Assert.assertTrue(outContent.toString().contains("[slp5] Preview 5"));
+        Assert.assertTrue(outContent.toString().contains("slbeta3"));
     }
 
     @Test

--- a/src/test/java/org/ballerinalang/command/ListCommandTest.java
+++ b/src/test/java/org/ballerinalang/command/ListCommandTest.java
@@ -40,7 +40,6 @@ public class ListCommandTest extends CommandTest {
         Assert.assertTrue(outContent.toString().contains("1.* channel"));
         Assert.assertTrue(outContent.toString().contains("1.2.20"));
         Assert.assertTrue(outContent.toString().contains("Swan Lake channel"));
-        Assert.assertTrue(outContent.toString().contains("2201"));
     }
 
     @Test

--- a/src/test/java/org/ballerinalang/distribution/UpdateToolTest.java
+++ b/src/test/java/org/ballerinalang/distribution/UpdateToolTest.java
@@ -252,14 +252,13 @@ public class UpdateToolTest {
         args.add("list");
         output = TestUtils.executeCommand(args);
         Assert.assertTrue(output.contains("Distributions available locally"));
-        Assert.assertTrue(output.contains("* [" + swanLakeLatestVersion + "] " +
-                TestUtils.getDisplayText(swanLakeLatestVersion)));
+        Assert.assertTrue(output.contains("* " + swanLakeLatestVersion));
         Assert.assertTrue(output.contains("Distributions available remotely"));
         Assert.assertTrue(output.contains("1.* channel"));
-        Assert.assertTrue(output.contains("[1.0.1] jballerina version 1.0.1"));
+        Assert.assertTrue(output.contains("1.2.16"));
         Assert.assertTrue(output.contains("Swan Lake channel"));
-        Assert.assertTrue(output.contains("[slp5] Preview 5"));
-        Assert.assertTrue(output.contains("[slalpha1] Alpha 1"));
+//        Assert.assertTrue(output.contains("slp5"));            Should be added after the release
+//        Assert.assertTrue(output.contains("[slalpha1] Alpha 1"));
 
         args.add("arg1");
         output = TestUtils.executeCommand(args);


### PR DESCRIPTION
## Purpose
Improve the bal dist list command to show the distribution version using SemVer. This enables adding extra argument to list down the entire distribution list available in a channel.  
## Goals
fixes #181 

