### PR TITLE
Add distribution availability check

### DIFF
--- a/src/main/java/org/ballerinalang/command/cmd/UseCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/UseCommand.java
@@ -17,6 +17,8 @@
 package org.ballerinalang.command.cmd;
 
 import org.ballerinalang.command.BallerinaCliCommands;
+import org.ballerinalang.command.util.Channel;
+import org.ballerinalang.command.util.Distribution;
 import org.ballerinalang.command.util.ErrorUtil;
 import org.ballerinalang.command.util.ToolUtil;
 import picocli.CommandLine;
@@ -68,8 +70,23 @@ public class UseCommand extends Command implements BCommand {
             return;
         }
         printStream.println("Distribution '" + distribution + "' not found");
-        printStream.println("Run 'bal dist pull " + distribution + "' to fetch and set the distribution as the " +
-                                    "active distribution");
+
+        List<Channel> channels = ToolUtil.getDistributions(printStream);
+        boolean validDistribution = false;
+        for (Channel channel : channels) {
+            for (Distribution dist : channel.getDistributions()) {
+                if (distribution.equals(dist.getVersion()) ) {
+                    validDistribution = true;
+                    printStream.println("Run 'bal dist pull " + distribution + "' to fetch and set the distribution " +
+                            "as the active distribution");
+                    break;
+                }
+            }
+        }
+        if (!validDistribution){
+            printStream.println( "'" + distribution + "' is not a valid distribution. Use 'bal dist list -a' for the " +
+                    "available distributions list");
+        }
     }
 
     @Override

--- a/src/test/java/org/ballerinalang/command/UseCommandTest.java
+++ b/src/test/java/org/ballerinalang/command/UseCommandTest.java
@@ -54,6 +54,11 @@ public class UseCommandTest extends CommandTest {
         new CommandLine(useCmd).parse("slp3");
         useCmd.execute();
         Assert.assertTrue(outContent.toString().contains("not found"));
+
+        UseCommand useCommandInvalidDist = new UseCommand(testStream);
+        new CommandLine(useCommandInvalidDist).parse("slbeta7");
+        useCommandInvalidDist.execute();
+        Assert.assertTrue(outContent.toString().contains("not a valid distribution"));
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Check whether the given distribution is available to use before suggest to use 'bal dist use <distribution>'

## Goals
fixes [#416](https://github.com/ballerina-platform/ballerina-distribution/issues/416)

<img width="1111" alt="Screenshot 2021-12-15 at 12 10 51" src="https://user-images.githubusercontent.com/66210480/146143461-b1d3843b-033b-4417-8731-f0714356240b.png">

