### PR TITLE
Update bal.bat to run cli commands for project paths with spaces - windows

### DIFF
--- a/resources/bin/bal.bat
+++ b/resources/bin/bal.bat
@@ -27,9 +27,9 @@ set RUN_BALLERINA=true
 set FILE_PATH=%CURRENT_PATH%..\distributions\ballerina-version
 set JAVA_CMD=java
 if "%1" == "dist" set dist=true
-if "%2" == "dist" set dist=true
+if "%~2" == "dist" set dist=true
 if "%1" == "update" set dist=true
-if "%2" == "update" set dist=true
+if "%~2" == "update" set dist=true
 if "%1" == "build" set dist=true
 if "%1" == "update" set update=true
 if "%1" == "build" set build=true
@@ -82,7 +82,7 @@ if "%RUN_BALLERINA%" == "true" (
         set BALLERINA_HOME=%%a
     )
     if exist %userprofile%\.ballerina\ballerina-version (
-        set "FILE_PATH=%userprofile%\.ballerina\ballerina-version"
+        set FILE_PATH="%userprofile%\.ballerina\ballerina-version"
     )
 
     SetLocal EnableDelayedExpansion
@@ -100,7 +100,7 @@ if "%RUN_BALLERINA%" == "true" (
 )
 set merge=false
 if "%1" == "help" (
-	if "%2" == "" set merge=true
+	if "%~2" == "" set merge=true
 )
 if "%1" == "-h" set merge=true
 if "%1" == "--help" set merge=true


### PR DESCRIPTION
## Purpose
>  fix https://github.com/ballerina-platform/ballerina-lang/issues/34692

## Approach
> getting rid of surrounding quotes when expanding cmd arguments with `%~2`

## Samples
![cli-pass](https://user-images.githubusercontent.com/57571152/149899893-c55db72b-ca71-4d00-8128-111404344f54.PNG)

## Related PRs
> https://github.com/ballerina-platform/ballerina-lang/pull/34703