### PR TITLE
Fix space issue in directory path

### DIFF
--- a/resources/bin/bal.bat
+++ b/resources/bin/bal.bat
@@ -27,9 +27,9 @@ set RUN_BALLERINA=true
 set FILE_PATH=%CURRENT_PATH%..\distributions\ballerina-version
 set JAVA_CMD=java
 if "%1" == "dist" set dist=true
-if "%2" == "dist" set dist=true
+if "%~2" == "dist" set dist=true
 if "%1" == "update" set dist=true
-if "%2" == "update" set dist=true
+if "%~2" == "update" set dist=true
 if "%1" == "build" set dist=true
 if "%1" == "update" set update=true
 if "%1" == "build" set build=true
@@ -100,7 +100,7 @@ if "%RUN_BALLERINA%" == "true" (
 )
 set merge=false
 if "%1" == "help" (
-	if "%2" == "" set merge=true
+	if "%~2" == "" set merge=true
 )
 if "%1" == "-h" set merge=true
 if "%1" == "--help" set merge=true


### PR DESCRIPTION
## Purpose
Currently when we run the `bal run "<path to ballerina file with spaces in the path>"`, it will give an error. This will fix the issue.

## Fixes
https://github.com/ballerina-platform/ballerina-lang/issues/34692