### PR TITLE
Reorder the list command output

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ version=1.3.11-SNAPSHOT
 ballerinaJreVersion=0.8.0
 
 # For test purpose
-swan-lake-version=2201.0.0
-swan-lake-spec-version=2022R1
-swan-lake-latest-version=2201.1.1
-swan-lake-latest-spec-version=2022R2
+swan-lake-version=2201.2.0
+swan-lake-spec-version=2022R3
+swan-lake-latest-version=2201.2.2
+swan-lake-latest-spec-version=2022R3
 1-x-channel-version=1.2.0
 1-x-channel-spec-version=2020R1
 1-x-channel-latest-version=1.2.16

--- a/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/ListCommand.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
@@ -109,6 +110,7 @@ public class ListCommand extends Command implements BCommand {
         String currentBallerinaVersion = ToolUtil.getCurrentBallerinaVersion();
         File folder = new File(ToolUtil.getDistributionsPath());
         File[] listOfFiles = folder.listFiles();
+        int maxListingDistributions = 10;
         try {
             JSONObject distList = new JSONObject();
             JSONArray channelsArr = new JSONArray();
@@ -159,29 +161,28 @@ public class ListCommand extends Command implements BCommand {
                     List<Distribution> channelDistList = channel.getDistributions();
                     if (channel.getName().equals("Swan Lake channel")) {
                         channelDistList.sort(Comparator.comparing(Distribution::getVersion));
+                        Collections.reverse(channelDistList);
                     }
                     if (!allFlag){
-                        if (channelDistList.size() > 10) {
-                            outStream.println("... To list all the previous distributions execute 'bal dist list -a'");
-                            int numDistributions = channelDistList.size();
-                            List<Distribution> recentDistributions = channelDistList.subList(numDistributions - 10,
-                                    numDistributions);
+                        if (channelDistList.size() > maxListingDistributions) {
+                            List<Distribution> recentDistributions = channelDistList.subList(0,
+                                    maxListingDistributions);
                             for (Distribution distribution : recentDistributions) {
                                 outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion(),
-                                        channelDistList.get(numDistributions - 1).getVersion()));
+                                        channelDistList.get(0).getVersion()));
                             }
                         }
                         else{
                             for (Distribution distribution : channelDistList) {
                                 outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion(),
-                                        channelDistList.get(channelDistList.size() - 1).getVersion()));
+                                        channelDistList.get(0).getVersion()));
                             }
                         }
                     }
                     else{
                         for (Distribution distribution : channelDistList) {
                             outStream.println(markVersion(currentBallerinaVersion, distribution.getVersion(),
-                                    channelDistList.get(channelDistList.size() - 1).getVersion()));
+                                    channelDistList.get(0).getVersion()));
                         }
                     }
                 }
@@ -197,6 +198,9 @@ public class ListCommand extends Command implements BCommand {
             ErrorUtil.printLauncherException(e, outStream);
         } finally {
             outStream.println();
+            if(!allFlag) {
+                outStream.println("Use 'bal dist list -a' to list all the distributions under each channel. ");
+            }
             outStream.println("Use 'bal help dist' for more information on specific commands.");
         }
     }

--- a/src/main/java/org/ballerinalang/command/util/ToolUtil.java
+++ b/src/main/java/org/ballerinalang/command/util/ToolUtil.java
@@ -246,9 +246,9 @@ public class ToolUtil {
 
                     if (channel == null) {
                         channel = new Channel(distribution.getChannel());
-                        channels.add(channel);
+                        channels.add(0, channel);
                     }
-                    channel.getDistributions().add(distribution);
+                    channel.getDistributions().add(0, distribution);
                 }
             }
         } catch (IOException e) {

--- a/src/test/java/org/ballerinalang/command/UseCommandTest.java
+++ b/src/test/java/org/ballerinalang/command/UseCommandTest.java
@@ -36,14 +36,14 @@ public class UseCommandTest extends CommandTest {
     @Test
     public void useCommandTest() {
         PullCommand pullCommand = new PullCommand(testStream);
-        new CommandLine(pullCommand).parse("slp1");
+        new CommandLine(pullCommand).parse("slbeta6");
         pullCommand.execute();
         UpdateCommand updateCommand = new UpdateCommand(testStream);
         new CommandLine(updateCommand).parse();
         updateCommand.execute();
 
         UseCommand useCommand = new UseCommand(testStream);
-        new CommandLine(useCommand).parse("slp1");
+        new CommandLine(useCommand).parse("slbeta6");
         useCommand.execute();
         Assert.assertTrue(outContent.toString().contains("successfully set as the active distribution"));
 


### PR DESCRIPTION
## Purpose
$title

## Goals
fixes #243 

## Approach 
These are the changes done for the output of bal dist list command

- Channels are listed from latest to oldest
- The distributions are listed from latest to oldest in each channel
- To list all the previous distributions execute 'bal dist list -a' phrase is removed and added Use 'bal dist list -a' to list all the distributions under each channel. line at the bottom of the command output when the -a flag is not used

Following will be the new output for bal dist list
![image](https://user-images.githubusercontent.com/66210480/199647049-7fe2dfbf-632a-4df2-920b-9c10f4742fe6.png)



