### PR TITLE
Simulate the update tool behaviour for a given tool and a distribution

### DIFF
--- a/.github/workflows/test_tool_behaviour.yml
+++ b/.github/workflows/test_tool_behaviour.yml
@@ -1,0 +1,140 @@
+name: Simulate Update Tool Behavior
+
+on:
+  workflow_dispatch:
+    inputs:
+      activeDistribution:
+        description: 'Active distribution while testing'
+        required: true
+      activeTool:
+        description: 'Active tool version at the beginning'
+        required: true
+      testOnDev:
+        description: 'Test on dev branch'
+        required: false
+        default: false
+      inputCommand:
+        description: 'Input command to be tested'
+        required: false
+        default: 'bal dist list'
+
+jobs:
+  ballerina-update-tool-test:
+    name: Simulate Ballerina Update Tool Behavior
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [  ubuntu-latest, macos-latest, windows-latest ]
+
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+
+      - name: Set env variables Ubuntu/Mac
+        if: matrix.os != 'windows-latest'
+        run: |
+          echo "activeDistribution=${{ github.event.inputs.activeDistribution }}" >> $GITHUB_ENV
+          echo "activeTool=${{ github.event.inputs.activeTool }}" >> $GITHUB_ENV
+          if [ "${{ github.event.inputs.testOnDev }}" = "true" ]; then
+            echo "env=dist-dev.ballerina.io" >> $GITHUB_ENV
+            echo "BALLERINA_DEV_UPDATE=true" >> $GITHUB_ENV
+          else
+            echo "env=dist.ballerina.io" >> $GITHUB_ENV
+          fi
+
+      - name: Install unzip on Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y unzip
+
+      - name: Install unzip on macOS
+        if: matrix.os == 'macos-latest'
+        run: brew install unzip
+
+      - name: Download and unzip Ballerina Ubuntu/Mac
+        if: matrix.os != 'windows-latest'
+        run: |
+          wget "https://$env/downloads/$activeDistribution/ballerina-$activeDistribution-swan-lake.zip"
+          unzip "ballerina-$activeDistribution-swan-lake.zip"
+        env:
+          JAVA_HOME: /usr/lib/jvm/default-jvm
+          JAVA_OPTS: -DBALLERINA_DEV_COMPILE_BALLERINA_ORG=true
+
+      - name: Download and unzip Ballerina Windows
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          if ${{ github.event.inputs.testOnDev }}=="true" (
+            curl -o "ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake.zip" "https://dist-dev.ballerina.io/downloads/${{ github.event.inputs.activeDistribution }}/ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake.zip"
+          ) else (
+            curl -o "ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake.zip" "https://dist.ballerina.io/downloads/${{ github.event.inputs.activeDistribution }}/ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake.zip"
+          )
+          PowerShell -Command "Expand-Archive -Path 'ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake.zip'"
+
+      - name: Download and unzip Update Tool Ubuntu/Mac
+        if: matrix.os != 'windows-latest'
+        run: |
+          wget "https://github.com/ballerina-platform/ballerina-update-tool/releases/download/v$activeTool/ballerina-command-$activeTool.zip"
+          unzip "ballerina-command-$activeTool.zip"
+
+      - name: Download and unzip Update Tool Windows
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          curl -fL -o "ballerina-command-windows-${{ github.event.inputs.activeTool }}.zip" "https://github.com/ballerina-platform/ballerina-update-tool/releases/download/v${{ github.event.inputs.activeTool }}/ballerina-command-windows-${{ github.event.inputs.activeTool }}.zip"
+          PowerShell -Command "Expand-Archive -Path 'ballerina-command-windows-${{ github.event.inputs.activeTool }}.zip'"
+
+      - name: Replace existing lib and bin directories Ubuntu/Mac
+        if: matrix.os != 'windows-latest'
+        run: |
+          rm -rf "ballerina-$activeDistribution-swan-lake/lib"
+          rm -rf "ballerina-$activeDistribution-swan-lake/bin"
+          mv "ballerina-command-$activeTool/lib" "ballerina-$activeDistribution-swan-lake/"
+          mv "ballerina-command-$activeTool/bin" "ballerina-$activeDistribution-swan-lake/"
+
+      - name: Replace existing lib and bin directories Windows
+        if: matrix.os == 'windows-latest'
+        shell: cmd
+        run: |
+          tree
+          dir
+          rmdir /s /q "ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\lib"
+          rmdir /s /q "ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\bin"
+          move "ballerina-command-windows-${{ github.event.inputs.activeTool }}\ballerina-command-windows-${{ github.event.inputs.activeTool }}\lib" "ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\"
+          move "ballerina-command-windows-${{ github.event.inputs.activeTool }}\ballerina-command-windows-${{ github.event.inputs.activeTool }}\bin" "ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\"
+
+      - name: Set Ballerina path variable Ubuntu/Mac
+        if: matrix.os != 'windows-latest'
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            echo "PATH=$PATH:/home/runner/work/ballerina-update-tool/ballerina-update-tool/ballerina-$activeDistribution-swan-lake/bin" >> $GITHUB_ENV
+          else
+            echo "PATH=$PATH:/Users/runner/work/ballerina-update-tool/ballerina-update-tool/ballerina-$activeDistribution-swan-lake/bin" >> $GITHUB_ENV
+          fi
+
+      - name: Set Ballerina path variable Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          echo "D:\a\ballerina-update-tool\ballerina-update-tool\ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\ballerina-${{ github.event.inputs.activeDistribution }}-swan-lake\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Run `bal -v`
+        run: |
+          bal -v
+
+      - name: Run `bal dist list`
+        run: bal dist list
+
+      - name: Run input command
+        run: ${{ github.event.inputs.inputCommand }}
+
+      - name: Run `bal -v` after command execution
+        run: bal -v
+
+      - name: Run `bal dist list` after command execution
+        run: bal dist list

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 group=org.ballerinalang
-version=1.3.16-SNAPSHOT
+version=1.4.0-SNAPSHOT
 ballerinaJreVersion=1.1.0
 jreVersion=17.0.7+7
 
 # For test purpose
 swan-lake-version=2201.2.0
 swan-lake-spec-version=2022R3
-swan-lake-latest-version=2201.7.0
+swan-lake-latest-version=2201.7.2
 swan-lake-latest-spec-version=2023R1
 1-x-channel-version=1.2.0
 1-x-channel-spec-version=2020R1
-1-x-channel-latest-version=1.2.40
+1-x-channel-latest-version=1.2.44


### PR DESCRIPTION
## Purpose
This workflow enables to create a testing environment with given distribution version and a given tool version as inputs. This can be used to test the released distributions and tools in `dev` and `prod` environments. A successful run can be found 
https://github.com/udda1996/ballerina-update-tool/actions/runs/5651868015 