### PR TITLE
Fix support for additional arguments in DefaultCommand

### DIFF
--- a/src/main/java/org/ballerinalang/command/cmd/DefaultCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/DefaultCommand.java
@@ -46,7 +46,7 @@ public class DefaultCommand extends Command implements BCommand {
     }
 
     @Override
-    public void execute() { 
+    public void execute() {
         if (versionFlag) {
             printVersionInfo();
             return;

--- a/src/main/java/org/ballerinalang/command/cmd/DefaultCommand.java
+++ b/src/main/java/org/ballerinalang/command/cmd/DefaultCommand.java
@@ -20,6 +20,7 @@ import org.ballerinalang.command.BallerinaCliCommands;
 import picocli.CommandLine;
 
 import java.io.PrintStream;
+import java.util.List;
 
 /**
  * This class represents the "default" command required by picocli.
@@ -37,12 +38,15 @@ public class DefaultCommand extends Command implements BCommand {
     @CommandLine.Option(names = { "--version", "-v" }, hidden = true)
     private boolean versionFlag;
 
+    @CommandLine.Parameters(description = "Help command name")
+    private List<String> helpCommands;
+
     public DefaultCommand(PrintStream printStream) {
         super(printStream);
     }
 
     @Override
-    public void execute() {
+    public void execute() { 
         if (versionFlag) {
             printVersionInfo();
             return;


### PR DESCRIPTION
## Purpose
In some bal --help <cmd-name> commands, after the help text, an error Unmatched argument at index 1: is printed

## Goals
Get rid of the error that was caused due to the default command not expecting additional arguments

## Approach
Add a `CommandLine.Parameters` such that we can take in a list of parameters avoiding the error and maybe put it to use in the future instead of modify the bal shell file

## User stories
When I first found out about ballerina and started tinkering with it, I ran into this error as well, it didn't make sense to me, and neither did I think it was actually a bug, but when I found this issue, I was relieved cause I spent quite some time trying to figure out how am I typing a `--help` command wrong. XD

## Release note
Fix unmatched argument log when running --help

Closes #309 