### PR TITLE
Add Trivy vulnerability scanning for on-demand and release builds

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -52,7 +52,7 @@ jobs:
             -d trivy-scan-target
 
       - name: Run Trivy vulnerability scan (SARIF output)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: 'trivy-scan-target'
@@ -62,7 +62,7 @@ jobs:
           exit-code: '0'
 
       - name: Run Trivy vulnerability scan (table output)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: 'true'
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,12 +7,18 @@ jobs:
   publish-release:
     name: Publish Release
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: write
+
     steps:
       - uses: actions/checkout@v2
+
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+
       - name: Set version env variable
         id: version-set
         run: |
@@ -20,7 +26,8 @@ jobs:
           echo "Release version: $RELEASE_VERSION"
           echo VERSION=$RELEASE_VERSION >> $GITHUB_ENV
           echo "::set-output name=version::$RELEASE_VERSION"
-      - name: Pre release depenency version update
+
+      - name: Pre release dependency version update
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
@@ -28,8 +35,10 @@ jobs:
           git config user.name ${{ secrets.BALLERINA_BOT_USERNAME }}
           git config user.email ${{ secrets.BALLERINA_BOT_EMAIL }}
           git checkout -b release-${VERSION}
+
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
+
       - name: Publish artifact
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
@@ -37,6 +46,43 @@ jobs:
           packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
         run: |
           ./gradlew release -Prelease.useAutomaticVersion=true --scan
+
+      # --- Trivy security scan on the release artifact ---
+
+      - name: Extract release distribution for scanning
+        run: |
+          mkdir -p trivy-scan-target
+          unzip -q build/distributions/ballerina-command-${{ steps.version-set.outputs.version }}.zip \
+            -d trivy-scan-target
+
+      - name: Run Trivy vulnerability scan (SARIF output)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: 'trivy-scan-target'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '0'
+
+      - name: Run Trivy vulnerability scan (table output)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: 'trivy-scan-target'
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '0'
+
+      - name: Upload Trivy results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-release'
+
+      # --- End Trivy scan ---
+
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -47,6 +93,7 @@ jobs:
           release_name: ${{ steps.version-set.outputs.version }}
           draft: false
           prerelease: false
+
       - name: Upload zip artifacts
         uses: actions/upload-release-asset@v1
         env:
@@ -56,6 +103,7 @@ jobs:
           asset_name: ballerina-command-${{ steps.version-set.outputs.version }}.zip
           asset_path: build/distributions/ballerina-command-${{ steps.version-set.outputs.version }}.zip
           asset_content_type: application/octet-stream
+
       - name: Upload Linux zip artifacts
         uses: actions/upload-release-asset@v1
         env:
@@ -65,6 +113,7 @@ jobs:
           asset_name: ballerina-command-linux-${{ steps.version-set.outputs.version }}.zip
           asset_path: build/distributions/ballerina-command-linux-${{ steps.version-set.outputs.version }}.zip
           asset_content_type: application/octet-stream
+
       - name: Upload MacOS zip artifacts
         uses: actions/upload-release-asset@v1
         env:
@@ -74,6 +123,7 @@ jobs:
           asset_name: ballerina-command-macos-${{ steps.version-set.outputs.version }}.zip
           asset_path: build/distributions/ballerina-command-macos-${{ steps.version-set.outputs.version }}.zip
           asset_content_type: application/octet-stream
+
       - name: Upload Windows zip artifacts
         uses: actions/upload-release-asset@v1
         env:
@@ -83,6 +133,7 @@ jobs:
           asset_name: ballerina-command-windows-${{ steps.version-set.outputs.version }}.zip
           asset_path: build/distributions/ballerina-command-windows-${{ steps.version-set.outputs.version }}.zip
           asset_content_type: application/octet-stream
+
       - name: Post release PR
         env:
           GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -12,12 +12,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'zulu'
 
       - name: Set version env variable
         id: version-set
@@ -25,7 +26,7 @@ jobs:
           RELEASE_VERSION=$(./gradlew properties | grep ^version: | cut -d\  -f2 | sed 's@-SNAPSHOT@@')
           echo "Release version: $RELEASE_VERSION"
           echo VERSION=$RELEASE_VERSION >> $GITHUB_ENV
-          echo "::set-output name=version::$RELEASE_VERSION"
+          echo "version=$RELEASE_VERSION" >> $GITHUB_OUTPUT
 
       - name: Pre release dependency version update
         env:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -39,20 +39,16 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Publish artifact
-        env:
-          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
-          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
-          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
-        run: |
-          ./gradlew release -Prelease.useAutomaticVersion=true --scan
+      # --- Trivy security scan before publishing ---
 
-      # --- Trivy security scan on the release artifact ---
+      - name: Pre-release build for security scan
+        run: ./gradlew clean build -x test
 
-      - name: Extract release distribution for scanning
+      - name: Extract distribution for security scan
         run: |
+          SNAPSHOT_VERSION=$(./gradlew properties -q | grep "^version:" | awk '{print $2}')
           mkdir -p trivy-scan-target
-          unzip -q build/distributions/ballerina-command-${{ steps.version-set.outputs.version }}.zip \
+          unzip -q build/distributions/ballerina-command-${SNAPSHOT_VERSION}.zip \
             -d trivy-scan-target
 
       - name: Run Trivy vulnerability scan (SARIF output)
@@ -67,12 +63,14 @@ jobs:
 
       - name: Run Trivy vulnerability scan (table output)
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
         with:
           scan-type: 'fs'
           scan-ref: 'trivy-scan-target'
           format: 'table'
           severity: 'HIGH,CRITICAL'
-          exit-code: '0'
+          exit-code: '1'
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -81,7 +79,15 @@ jobs:
           sarif_file: 'trivy-results.sarif'
           category: 'trivy-release'
 
-      # --- End Trivy scan ---
+      # --- End Trivy scan — release only proceeds if scan passed ---
+
+      - name: Publish artifact
+        env:
+          GITHUB_TOKEN: ${{ secrets.BALLERINA_BOT_TOKEN }}
+          packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
+          packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
+        run: |
+          ./gradlew release -Prelease.useAutomaticVersion=true --scan
 
       - name: Create release
         id: create_release

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,85 @@
+name: Trivy Vulnerability Scan
+
+on:
+  workflow_dispatch:
+    inputs:
+      severity:
+        description: 'Comma-separated severity levels to report (UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL)'
+        required: false
+        default: 'HIGH,CRITICAL'
+      fail_on_findings:
+        description: 'Fail the workflow if vulnerabilities are found at the specified severity'
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  trivy-scan:
+    name: Trivy Scan
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build distribution
+        run: ./gradlew clean build -x test
+        env:
+          TEST_MODE_ACTIVE: true
+
+      - name: Get version
+        id: version
+        run: |
+          VERSION=$(./gradlew properties -q | grep "^version:" | awk '{print $2}')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Extract distribution zip
+        run: |
+          mkdir -p trivy-scan-target
+          unzip -q build/distributions/ballerina-command-${{ steps.version.outputs.version }}.zip \
+            -d trivy-scan-target
+
+      - name: Run Trivy scan (SARIF output)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: 'trivy-scan-target'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: ${{ github.event.inputs.severity || 'HIGH,CRITICAL' }}
+          exit-code: '0'
+
+      - name: Run Trivy scan (table output)
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'fs'
+          scan-ref: 'trivy-scan-target'
+          format: 'table'
+          severity: ${{ github.event.inputs.severity || 'HIGH,CRITICAL' }}
+          exit-code: ${{ github.event.inputs.fail_on_findings == 'true' && '1' || '0' }}
+
+      - name: Upload Trivy results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: 'trivy-on-demand'
+
+      - name: Upload scan report as artifact
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: trivy-results-${{ steps.version.outputs.version }}
+          path: trivy-results.sarif
+          retention-days: 30

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -51,7 +51,7 @@ jobs:
             -d trivy-scan-target
 
       - name: Run Trivy scan (SARIF output)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'fs'
           scan-ref: 'trivy-scan-target'
@@ -61,7 +61,7 @@ jobs:
           exit-code: '0'
 
       - name: Run Trivy scan (table output)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         env:
           TRIVY_SKIP_DB_UPDATE: 'true'
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -22,12 +22,13 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: '8'
+          distribution: 'zulu'
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
@@ -41,7 +42,6 @@ jobs:
         id: version
         run: |
           VERSION=$(./gradlew properties -q | grep "^version:" | awk '{print $2}')
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Extract distribution zip
@@ -57,17 +57,19 @@ jobs:
           scan-ref: 'trivy-scan-target'
           format: 'sarif'
           output: 'trivy-results.sarif'
-          severity: ${{ github.event.inputs.severity || 'HIGH,CRITICAL' }}
+          severity: ${{ inputs.severity }}
           exit-code: '0'
 
       - name: Run Trivy scan (table output)
         uses: aquasecurity/trivy-action@0.28.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
         with:
           scan-type: 'fs'
           scan-ref: 'trivy-scan-target'
           format: 'table'
-          severity: ${{ github.event.inputs.severity || 'HIGH,CRITICAL' }}
-          exit-code: ${{ github.event.inputs.fail_on_findings == 'true' && '1' || '0' }}
+          severity: ${{ inputs.severity }}
+          exit-code: ${{ inputs.fail_on_findings && '1' || '0' }}
 
       - name: Upload Trivy results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
@@ -77,7 +79,7 @@ jobs:
           category: 'trivy-on-demand'
 
       - name: Upload scan report as artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: trivy-results-${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary

- **New `trivy-scan.yml`**: On-demand (`workflow_dispatch`) Trivy filesystem scan against the built `ballerina-command-<version>.zip` artifact. Configurable severity levels (default: `HIGH,CRITICAL`) and an optional `fail_on_findings` gate. Results are uploaded to the GitHub Security tab and attached as a downloadable artifact.
- **Updated `publish-release.yml`**: Trivy scan runs automatically after the release artifact is built and before the GitHub Release is created. Findings appear in the Security tab under the `trivy-release` category.

## How the scan works

Both workflows:
1. Build the Gradle distribution to produce `build/distributions/ballerina-command-<version>.zip`
2. Extract the ZIP and run `trivy fs` over the contents (scans embedded JARs for CVEs)
3. Upload a SARIF report to **Security → Code scanning**

## Test plan

- [ ] Trigger `Trivy Vulnerability Scan` from Actions on any branch and verify the scan runs and results appear in the Security tab
- [ ] Verify `publish-release.yml` scan steps are correctly positioned after build and before release creation
- [ ] Confirm `fail_on_findings: true` in the on-demand workflow causes the job to exit non-zero when findings are present

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request adds artifact-level vulnerability scanning to CI/CD by introducing an on-demand Trivy scan workflow and integrating Trivy into the release pipeline.

Changes overview

- New on-demand workflow (.github/workflows/trivy-scan.yml)
  - Adds a manual "Trivy Vulnerability Scan" workflow with inputs for comma-separated severity levels (default: HIGH,CRITICAL) and a boolean fail_on_findings gate.
  - Builds the Gradle distribution, extracts build/distributions/ballerina-command-<version>.zip, and scans the extracted filesystem (including embedded JARs) using Trivy.
  - Produces a SARIF report uploaded to the repository Security → Code scanning and saves the SARIF as a downloadable workflow artifact; also emits a human-readable table output used to enforce the optional fail_on_findings behavior.

- Updated release workflow (.github/workflows/publish-release.yml)
  - Runs a Trivy scan automatically after the release artifact is built and before the GitHub Release is created; findings are uploaded as SARIF to the Security tab under a release-specific category.
  - Grants the publish-release job the permissions required for SARIF upload and preserves the existing release publishing flow while adding the scan as a quality-assurance step. The job can be configured to fail based on scan findings.

Other notable changes
- Pins the aquasecurity/trivy-action to a specific commit SHA (v0.35.0-equivalent) across workflows to avoid silent breakage from moving or deleted tags.
- Minor fixes (whitespace and a corrected step name) and permission adjustments to support SARIF uploads.

Intent and impact
- Adds automated, reportable scanning of built artifacts to surface issues before release and to enable configurable enforcement in on-demand and release builds.
- Improves release pipeline quality checks while keeping existing release mechanics intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->