### PR TITLE
Add support for Java 25 (jdk-25.0.3+9)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 group=org.ballerinalang
-version=1.5.2-SNAPSHOT
+version=1.6.0-SNAPSHOT
 ballerinaJreVersion=1.1.0
 jreVersion=25.0.3+9-jre
 
 # For test purpose
 swan-lake-version=2201.2.0
 swan-lake-spec-version=2022R3
-swan-lake-latest-version=2201.13.3
+swan-lake-latest-version=2201.13.4
 swan-lake-latest-spec-version=2024R1
-swan-lake-latest-dependency-version=jdk-25.0.3+9-jre
+swan-lake-latest-dependency-version=jdk-21.0.5+11-jre
 1-x-channel-version=1.2.0
 1-x-channel-dependency-version=jdk8u202-b08-jre
 1-x-channel-spec-version=2020R1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,14 +1,14 @@
 group=org.ballerinalang
 version=1.5.2-SNAPSHOT
 ballerinaJreVersion=1.1.0
-jreVersion=21.0.5+11-jre
+jreVersion=25.0.3+9-jre
 
 # For test purpose
 swan-lake-version=2201.2.0
 swan-lake-spec-version=2022R3
 swan-lake-latest-version=2201.13.3
 swan-lake-latest-spec-version=2024R1
-swan-lake-latest-dependency-version=jdk-21.0.5+11-jre
+swan-lake-latest-dependency-version=jdk-25.0.3+9-jre
 1-x-channel-version=1.2.0
 1-x-channel-dependency-version=jdk8u202-b08-jre
 1-x-channel-spec-version=2020R1

--- a/resources/bin/bal
+++ b/resources/bin/bal
@@ -23,7 +23,9 @@
   fi
 
   JAVA_COMMAND=java
-  if test -d "$CURRENT_PATH/../dependencies/jdk-21.0.5+11-jre"; then
+  if test -d "$CURRENT_PATH/../dependencies/jdk-25.0.3+9-jre"; then
+      JAVA_COMMAND="$CURRENT_PATH/../dependencies/jdk-25.0.3+9-jre/bin/java"
+  elif test -d "$CURRENT_PATH/../dependencies/jdk-21.0.5+11-jre"; then
       JAVA_COMMAND="$CURRENT_PATH/../dependencies/jdk-21.0.5+11-jre/bin/java"
   elif test -d "$CURRENT_PATH/../dependencies/jdk-17.0.7+7-jre"; then
     JAVA_COMMAND="$CURRENT_PATH/../dependencies/jdk-17.0.7+7-jre/bin/java"

--- a/resources/bin/bal.bat
+++ b/resources/bin/bal.bat
@@ -39,33 +39,37 @@ if "%1" == "update" set update=true
 if "%1" == "build" set build=true
 SetLocal EnableDelayedExpansion
 
-if exist %CURRENT_PATH%..\dependencies\jdk-21.0.5+11-jre (
-   set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-21.0.5+11-jre\bin\java
+if exist %CURRENT_PATH%..\dependencies\jdk-25.0.3+9-jre (
+   set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-25.0.3+9-jre\bin\java
 ) else (
-    if exist %CURRENT_PATH%..\dependencies\jdk-17.0.7+7-jre (
-       set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-17.0.7+7-jre\bin\java
+    if exist %CURRENT_PATH%..\dependencies\jdk-21.0.5+11-jre (
+       set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-21.0.5+11-jre\bin\java
     ) else (
-        if exist %CURRENT_PATH%..\dependencies\jdk-11.0.18+10-jre (
-           set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-11.0.18+10-jre\bin\java
+        if exist %CURRENT_PATH%..\dependencies\jdk-17.0.7+7-jre (
+           set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-17.0.7+7-jre\bin\java
         ) else (
-            if exist %CURRENT_PATH%..\dependencies\jdk-11.0.15+10-jre (
-               set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-11.0.15+10-jre\bin\java
+            if exist %CURRENT_PATH%..\dependencies\jdk-11.0.18+10-jre (
+               set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-11.0.18+10-jre\bin\java
             ) else (
-                if exist %CURRENT_PATH%..\dependencies\jdk-11.0.8+10-jre (
-                   set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-11.0.8+10-jre\bin\java
+                if exist %CURRENT_PATH%..\dependencies\jdk-11.0.15+10-jre (
+                   set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-11.0.15+10-jre\bin\java
                 ) else (
-                    if exist %CURRENT_PATH%..\dependencies\jdk8u332-b09-jre (
-                       set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk8u332-b09-jre\bin\java
+                    if exist %CURRENT_PATH%..\dependencies\jdk-11.0.8+10-jre (
+                       set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk-11.0.8+10-jre\bin\java
                     ) else (
-                        if exist %CURRENT_PATH%..\dependencies\jdk8u265-b01-jre (
-                           set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk8u265-b01-jre\bin\java
+                        if exist %CURRENT_PATH%..\dependencies\jdk8u332-b09-jre (
+                           set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk8u332-b09-jre\bin\java
                         ) else (
-                            if exist %CURRENT_PATH%..\dependencies\jdk8u202-b08-jre (
-                               set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk8u202-b08-jre\bin\java
+                            if exist %CURRENT_PATH%..\dependencies\jdk8u265-b01-jre (
+                               set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk8u265-b01-jre\bin\java
                             ) else (
-                                if not exist "%JAVA_HOME%" (
-                                   echo Compatible JRE not found. Please follow the instructions in ^<BALLERINA_HOME^>\INSTALL.txt to install and setup Ballerina.
-                                   exit /b
+                                if exist %CURRENT_PATH%..\dependencies\jdk8u202-b08-jre (
+                                   set JAVA_CMD=%CURRENT_PATH%..\dependencies\jdk8u202-b08-jre\bin\java
+                                ) else (
+                                    if not exist "%JAVA_HOME%" (
+                                       echo Compatible JRE not found. Please follow the instructions in ^<BALLERINA_HOME^>\INSTALL.txt to install and setup Ballerina.
+                                       exit /b
+                                    )
                                 )
                             )
                         )


### PR DESCRIPTION
Bump jreVersion to jdk-25.0.3+9-jre and add a corresponding lookup branch in bal/bal.bat, following the same pattern used to add Java 17 (#307) and Java 21 (#373) support.

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the default bundled runtime configuration to Java 25 (`jdk-25.0.3+9-jre`) and refreshed the Swan Lake latest version used by the tool.
- Enhanced the Unix (`resources/bin/bal`) and Windows (`resources/bin/bal.bat`) launch scripts to prioritize the Java 25 bundled JRE when available, while keeping the existing fallback behavior for older JRE versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->